### PR TITLE
simplify forum namespaces

### DIFF
--- a/tests/mod_forum/discussion_created/discussion_created_test.php
+++ b/tests/mod_forum/discussion_created/discussion_created_test.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace logstore_xapi\mod_forum\discussion_created;
+namespace logstore_xapi\mod_forum;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/tests/mod_forum/discussion_subcription_created/discussion_subscription_created_test.php
+++ b/tests/mod_forum/discussion_subcription_created/discussion_subscription_created_test.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace logstore_xapi\mod_forum\discussion_created;
+namespace logstore_xapi\mod_forum;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/tests/mod_forum/discussion_subcription_deleted/discussion_subscription_deleted_test.php
+++ b/tests/mod_forum/discussion_subcription_deleted/discussion_subscription_deleted_test.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace logstore_xapi\mod_forum\discussion_created;
+namespace logstore_xapi\mod_forum;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/tests/mod_forum/discussion_viewed/existing_discussion_viewed/existing_discussion_viewed_test.php
+++ b/tests/mod_forum/discussion_viewed/existing_discussion_viewed/existing_discussion_viewed_test.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace logstore_xapi\mod_forum\discussion_viewed\existing_discussion_viewed;
+namespace logstore_xapi\mod_forum;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/tests/mod_forum/post_created/post_created_test.php
+++ b/tests/mod_forum/post_created/post_created_test.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace logstore_xapi\mod_forum\post_created;
+namespace logstore_xapi\mod_forum;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/tests/mod_forum/post_deleted/post_deleted_test.php
+++ b/tests/mod_forum/post_deleted/post_deleted_test.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace logstore_xapi\mod_forum\post_created;
+namespace logstore_xapi\mod_forum;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/tests/mod_forum/post_updated/post_updated_test.php
+++ b/tests/mod_forum/post_updated/post_updated_test.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace logstore_xapi\mod_forum\post_created;
+namespace logstore_xapi\mod_forum;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/tests/mod_forum/subscription_created/subscription_created_test.php
+++ b/tests/mod_forum/subscription_created/subscription_created_test.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace logstore_xapi\mod_forum\discussion_created;
+namespace logstore_xapi\mod_forum;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/tests/mod_forum/subscription_deleted/subscription_deleted_test.php
+++ b/tests/mod_forum/subscription_deleted/subscription_deleted_test.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace logstore_xapi\mod_forum\discussion_created;
+namespace logstore_xapi\mod_forum;
 
 defined('MOODLE_INTERNAL') || die();
 


### PR DESCRIPTION
**Description**
simplify the namespaces of forum tests as they were wrong before, and as far as i can tell they dont do anything
